### PR TITLE
Add support for Triplequote Hydra

### DIFF
--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/PluginsParam.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/PluginsParam.scala
@@ -7,6 +7,10 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 
 object PluginsParam {
+  val scalaPluginOrgs = Set(
+    "net.alchim31.maven",
+    "com.triplequote.maven"
+  )
 
   def apply(plugins: java.util.List[Plugin]): MojoParam = {
     _.withScalacOptions(
@@ -18,7 +22,7 @@ object PluginsParam {
 
     def findScalaPlugin: Option[Plugin] = {
       plugins.asScala.find { plugin =>
-        plugin.getGroupId == "net.alchim31.maven" && plugin.getArtifactId == "scala-maven-plugin"
+        scalaPluginOrgs.contains(plugin.getGroupId) && plugin.getArtifactId == "scala-maven-plugin"
       }
     }
   }


### PR DESCRIPTION
When testing for scalacOptions to include `-Ywarn-unused`, the scalacOptions are retrieved based on the maven plugin coordinates. For Hydra, the orgId is different from the OSS maven plugin, so we relax the test to accept the triplequote org as well.

One of our customers is using scalafix and Hydra, and would like to be able to use this via Maven. I tested this manually on a test project, as well as ran all existing tests.