### PR TITLE
POM: cross-compile for 2.11.12, 2.12.12 and 2.13.3

### DIFF
--- a/.github/workflows/scalafix.yml
+++ b/.github/workflows/scalafix.yml
@@ -8,6 +8,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - "-Pscala-2.11"
+          - "-Pscala-2.12"
+          - "-Pscala-2.13"
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
@@ -15,4 +22,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Check code with Scalafix
-      run: mvn compile test-compile scalafix:scalafix -Dscalafix.mode=CHECK
+      run: mvn ${{ matrix.command }} compile test-compile scalafix:scalafix -Dscalafix.mode=CHECK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - "-Pscala-2.11"
+          - "-Pscala-2.12"
+          - "-Pscala-2.13"
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
@@ -15,4 +22,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn test
+      run: mvn ${{ matrix.command }} test

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add plugin into `plugins` node of `pom.xml`:
 <plugins>
     <plugin>
         <groupId>io.github.evis</groupId>
-        <artifactId>scalafix-maven-plugin</artifactId>
+        <artifactId>scalafix-maven-plugin_2.12</artifactId>
         <version>0.1.4_0.9.23</version>
     </plugin>
 </plugins>
@@ -25,7 +25,7 @@ In order to execute semantic rules (e.g., `RemoveUnused`), you need to enable Se
 ```xml
 <plugin>
     <groupId>net.alchim31.maven</groupId>
-    <artifactId>scala-maven-plugin</artifactId>
+    <artifactId>scala-maven-plugin_${scala.binary.version}</artifactId>
     <version>${scala-maven-plugin.version}</version>
     <executions>
         <execution>
@@ -42,7 +42,7 @@ In order to execute semantic rules (e.g., `RemoveUnused`), you need to enable Se
         <compilerPlugins>
             <compilerPlugin>
                 <groupId>org.scalameta</groupId>
-                <artifactId>semanticdb-scalac_${scala.version}</artifactId>
+                <artifactId>semanticdb-scalac_${scala.binary.version}</artifactId>
                 <version>${semanticdb.version}</version>
             </compilerPlugin>
         </compilerPlugins>
@@ -57,7 +57,7 @@ By default, sources should be located inside `src/main/scala` directory. Though,
 ```xml
 <plugin>
     <groupId>io.github.evis</groupId>
-    <artifactId>scalafix-maven-plugin</artifactId>
+    <artifactId>scalafix-maven-plugin_2.11</artifactId>
     <version>0.1.4_0.9.23</version>
     <configuration>
         <sourceDirectory>src/main/my-sources-dir</sourceDirectory>
@@ -95,7 +95,7 @@ Also, you can pass parameters via `pom.xml`:
 <plugins>
     <plugin>
         <groupId>io.github.evis</groupId>
-        <artifactId>scalafix-maven-plugin</artifactId>
+        <artifactId>scalafix-maven-plugin_2.13</artifactId>
         <version>0.1.4_0.9.23</version>
         <configuration>
             <mode>CHECK</mode>
@@ -110,7 +110,7 @@ If you want to use external rules, add jars containing rules to dependencies of 
 ```xml
 <plugin>
     <groupId>io.github.evis</groupId>
-    <artifactId>scalafix-maven-plugin</artifactId>
+    <artifactId>scalafix-maven-plugin_2.12</artifactId>
     <version>0.1.4_0.9.23</version>
     <dependencies>
         <dependency>
@@ -150,13 +150,13 @@ CLI name | Maven configuration name | Type | Description
                 <plugins>
                     <plugin>
                         <groupId>net.alchim31.maven</groupId>
-                        <artifactId>scala-maven-plugin</artifactId>
+                        <artifactId>scala-maven-plugin_${scala.binary.version}</artifactId>
                         <version>${scala-maven-plugin.version}</version>
                         <configuration>
                             <compilerPlugins>
                                 <compilerPlugin>
                                     <groupId>org.scalameta</groupId>
-                                    <artifactId>semanticdb-scalac_${scala.version}</artifactId>
+                                    <artifactId>semanticdb-scalac_${scala.binary.version}</artifactId>
                                     <version>${semanticdb.version}</version>
                                 </compilerPlugin>
                             </compilerPlugins>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     </description>
     <url>https://github.com/evis/scalafix-maven-plugin</url>
     <groupId>io.github.evis</groupId>
-    <artifactId>scalafix-maven-plugin</artifactId>
-    <version>0.1.4_0.9.23</version>
+    <artifactId>scalafix-maven-plugin_${scala.major.version}</artifactId>
+    <version>0.1.4_${scalafix.version}</version>
     <licenses>
         <license>
             <name>BSD-3-Clause</name>
@@ -30,11 +30,35 @@
         <developerConnection>scm:git:ssh://github.com:evis/scalafix-maven-plugin.git</developerConnection>
         <url>http://github.com/evis/scalafix-maven-plugin/tree/master</url>
     </scm>
+    <profiles>
+        <profile>
+            <id>scala-2.11</id>
+            <properties>
+                <scala.major.version>2.11</scala.major.version>
+                <scala.patch.version>12</scala.patch.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.12</id>
+            <properties>
+                <scala.major.version>2.12</scala.major.version>
+                <scala.patch.version>12</scala.patch.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.13</id>
+            <properties>
+                <scala.major.version>2.13</scala.major.version>
+                <scala.patch.version>3</scala.patch.version>
+            </properties>
+        </profile>
+    </profiles>
     <properties>
         <maven-plugin.version>3.6.0</maven-plugin.version>
         <scalafix.version>0.9.23</scalafix.version>
         <scala.major.version>2.12</scala.major.version>
-        <scala.version>2.12.12</scala.version>
+        <scala.patch.version>12</scala.patch.version>
+        <scala.version>${scala.major.version}.${scala.patch.version}</scala.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
         <!-- java 8 is required for static interface
@@ -49,6 +73,7 @@
         <scalafmt.version>1.5.1</scalafmt.version>
         <mvn-scalafmt.version>0.11</mvn-scalafmt.version>
         <semanticdb.version>4.3.24</semanticdb.version>
+        <scala-cross-maven-plugin.version>0.3.0</scala-cross-maven-plugin.version>
     </properties>
     <packaging>maven-plugin</packaging>
     <build>
@@ -56,6 +81,19 @@
         <sourceDirectory>src/main/scala</sourceDirectory>
         <testSourceDirectory>src/test/scala</testSourceDirectory>
         <plugins>
+            <plugin>
+                <groupId>org.spurint.maven.plugins</groupId>
+                <artifactId>scala-cross-maven-plugin</artifactId>
+                <version>${scala-cross-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>rewrite-pom</id>
+                        <goals>
+                            <goal>rewrite-pom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -71,7 +109,7 @@
                 <version>${scala-maven-plugin.version}</version>
                 <configuration>
                     <args>
-                        <arg>-Ywarn-adapted-args</arg>
+                        <arg>-target:jvm-1.8</arg>
                         <arg>-Ywarn-unused</arg>
                     </args>
                     <compilerPlugins>
@@ -99,8 +137,9 @@
                      strange ArrayIndexOutOfBoundsException on building plugin.
                      source: https://stackoverflow.com/a/47043146/5053865 -->
                 <configuration>
+                    <goalPrefix>scalafix</goalPrefix>
                     <mojoDependencies>
-                        <param>io.github.evis:scalafix-maven-plugin</param>
+                        <param>${groupId}:${artifactId}</param>
                     </mojoDependencies>
                 </configuration>
             </plugin>

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/phases/Run.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/phases/Run.scala
@@ -13,7 +13,7 @@ trait Run
     val scalafix = loadScalafix()
     val arguments = buildScalafixArguments(scalafix, params)
     logger.log(arguments)
-    val errors = arguments.map(_.run().toList).getOrElse(Nil)
+    val errors = arguments.fold(_ => Nil, _.run().toList)
     showErrors(errors)
   }
 }


### PR DESCRIPTION
Since this plugin uses a specific version of scalafix which, in turn, requires a given version of semanticdb that must be consistent with the scala version used in building the user's project, we must publish separate versions of the plugin for different versions of scala.

Fixes #10. Fixes #11.