### PR TITLE
ScalafixMojo: pass the entire project, not parts

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -34,4 +34,5 @@ rewrite.neverInfix.excludeFilters = [
   allElementsOf
   inOrderElementsOf
   theSameElementsAs
+  length
 ]

--- a/README.md
+++ b/README.md
@@ -124,14 +124,21 @@ If you want to use external rules, add jars containing rules to dependencies of 
 
 ### Plugin parameters
 
-CLI name | Maven configuration name | Type | Description
+CLI name | Maven configuration name | Maven type | Description
 --- | --- | --- | ---
 `scalafix.mode` | `mode` | `ScalafixMainMode`: either `IN_PLACE`, `CHECK`, `STDOUT` or `AUTO_SUPPRESS_LINTER_ERRORS` (default: `IN_PLACE`) | Describes mode in which Scalafix runs. Description of different parameter values can be found in [Scalafix javadoc](https://static.javadoc.io/ch.epfl.scala/scalafix-interfaces/0.9.33/scalafix/interfaces/ScalafixMainMode.html).
-`scalafix.command.line.args` | `commandLineArgs` | `String` (default: empty string) | Custom CLI arguments to pass into Scalafix. Description of available arguments can be found in [Scalafix CLI documentation](https://scalacenter.github.io/scalafix/docs/users/installation.html#help).
+`scalafix.command.line.args` | `commandLineArgs` | `List[String]` (default: empty) | Custom CLI arguments to pass into Scalafix. Description of available arguments can be found in [Scalafix CLI documentation](https://scalacenter.github.io/scalafix/docs/users/installation.html#help).
 `scalafix.skip` | `skip` | `Boolean` (default: `false`) | Whether we should skip all formatting.
 `scalafix.skip.main` | `skipMain` | `Boolean` (default: `false`) | Whether we should skip formatting of application/library sources (by default located in `main/scala`).
 `scalafix.skip.test` | `skipTest` | `Boolean` (default: `false`) | Whether we should skip formatting of test sources (by default located in `/test/scala`).
 `scalafix.config` | `config` | `File` (default: `.scalafix.conf`) | Configuration with rules to invoke for Scalafix.
+
+> The plugin determines code paths to process the same way the compiler would; by default, from
+> `build.sourceDirectory` property, but could be added by another plugin 
+> (e.g., `build-helper-maven-plugin` and `scala-maven-plugin` have a way to define multiple paths).
+>
+> If a plugin defines those paths, be sure to invoke `mvn` with the phase in which that happens;
+> for instance: `mvn initialize scalafix:scalafix`.
 
 ### Tips and tricks
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ CLI name | Maven configuration name | Maven type | Description
 `scalafix.skip.main` | `skipMain` | `Boolean` (default: `false`) | Whether we should skip formatting of application/library sources (by default located in `main/scala`).
 `scalafix.skip.test` | `skipTest` | `Boolean` (default: `false`) | Whether we should skip formatting of test sources (by default located in `/test/scala`).
 `scalafix.config` | `config` | `File` (default: `.scalafix.conf`) | Configuration with rules to invoke for Scalafix.
+`scalafix.mainSourceDirectories` | `mainSourceDirectories` | `List[File]` (default: see below) | Which main source directories to format.
+`scalafix.testSourceDirectories` | `testSourceDirectories` | `List[File]` (default: see below) | Which test source directories to format.
 
 > The plugin determines code paths to process the same way the compiler would; by default, from
 > `build.sourceDirectory` property, but could be added by another plugin 

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         </profile>
     </profiles>
     <properties>
+        <maven-core.version>3.6.2</maven-core.version>
         <maven-plugin-api.version>3.8.4</maven-plugin-api.version>
         <maven-plugin-annotations.version>3.6.2</maven-plugin-annotations.version>
         <maven-plugin-plugin.version>3.6.2</maven-plugin-plugin.version>
@@ -226,6 +227,12 @@
         </plugins>
     </build>
     <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven-core.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,8 @@
         <maven-plugin-annotations.version>3.6.2</maven-plugin-annotations.version>
         <maven-plugin-plugin.version>3.6.2</maven-plugin-plugin.version>
         <scalafix.version>0.9.33</scalafix.version>
+        <!-- the version we'll use ourselves; can't be current as it's not built yet -->
+        <scalafix-plugin.version>0.1.4_0.9.23</scalafix-plugin.version>
         <scala.major.version>2.12</scala.major.version>
         <scala.patch.version>15</scala.patch.version>
         <scala.version>${scala.major.version}.${scala.patch.version}</scala.version>
@@ -222,7 +224,7 @@
             <plugin>
                 <groupId>io.github.evis</groupId>
                 <artifactId>scalafix-maven-plugin_${scala.major.version}</artifactId>
-                <version>${version}</version>
+                <version>${scalafix-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/mojo/ScalafixMojo.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/mojo/ScalafixMojo.scala
@@ -1,10 +1,10 @@
 package io.github.evis.scalafix.maven.plugin.mojo
 
 import java.io.File
+import java.nio.file.Path
+import java.util.{List => JList}
 
 import io.github.evis.scalafix.maven.plugin.params._
-import org.apache.maven.artifact.Artifact
-import org.apache.maven.model.Plugin
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.{Mojo, Parameter, ResolutionScope}
 import org.apache.maven.project.MavenProject
@@ -33,47 +33,11 @@ final class ScalafixMojo extends AbstractMojo {
     readonly = true)
   private var project: MavenProject = _
 
-  @Parameter(
-    defaultValue = "${project.build.sourceDirectory}/../scala",
-    required = true,
-    readonly = true)
-  private var sourceDirectory: String = _
-
-  @Parameter(
-    defaultValue = "${project.build.testSourceDirectory}/../scala",
-    required = true,
-    readonly = true)
-  private var testSourceDirectory: String = _
-
-  @Parameter(
-    defaultValue = "${project.artifacts}",
-    required = true,
-    readonly = true)
-  private var projectDependencies: java.util.Set[Artifact] = _
-
-  @Parameter(
-    defaultValue = "${project.build.outputDirectory}",
-    required = true,
-    readonly = true)
-  private var compiledDirectory: String = _
-
-  @Parameter(
-    defaultValue = "${project.build.testOutputDirectory}",
-    required = true,
-    readonly = true)
-  private var testCompiledDirectory: String = _
-
-  @Parameter(
-    defaultValue = "${project.build.plugins}",
-    required = true,
-    readonly = true)
-  private var plugins: java.util.List[Plugin] = _
-
   @Parameter(property = "scalafix.mode", defaultValue = "IN_PLACE")
   private var mode: ScalafixMainMode = _
 
   @Parameter(property = "scalafix.command.line.args")
-  private var commandLineArgs: java.util.List[String] = _
+  private var commandLineArgs: JList[String] = _
 
   @Parameter(property = "scalafix.skip", defaultValue = "false")
   private var skip: Boolean = _
@@ -94,14 +58,15 @@ final class ScalafixMojo extends AbstractMojo {
       getLog.info(
         "Skip scalafix since both skip.main and skip.test flags passed")
     } else {
-      val mainOutputs = if (skipMain) Nil else List(compiledDirectory)
-      val testOutputs = if (skipTest) Nil else List(testCompiledDirectory)
+      val bld = project.getBuild
+      val mainOutputs = if (skipMain) Nil else List(bld.getOutputDirectory)
+      val testOutputs = if (skipTest) Nil else List(bld.getTestOutputDirectory)
       val params =
         List(
           getSourceParam,
-          ProjectDependenciesParam(projectDependencies.asScala),
+          ProjectDependenciesParam(project.getArtifacts.asScala),
           CompiledDirectoryParam(mainOutputs ++ testOutputs),
-          PluginsParam(plugins.asScala),
+          PluginsParam(bld.getPlugins.asScala),
           ModeParam(mode),
           ConfigParam(config),
           CommandLineArgsParam(commandLineArgs)
@@ -111,9 +76,18 @@ final class ScalafixMojo extends AbstractMojo {
   }
 
   private def getSourceParam: MojoParam = {
-    val main = if (skipMain) Nil else List(sourceDirectory)
-    val test = if (skipTest) Nil else List(testSourceDirectory)
+    val lookup = new SourceDirectoryLookup(FileOps, project)
+    val main = checkSources("main", skipMain)(lookup.getMain(Nil))
+    val test = checkSources("test", skipTest)(lookup.getTest(Nil))
     SourceDirectoryParam(main ++ test)
+  }
+
+  private def checkSources(flagName: String, skip: Boolean)(
+      getPaths: => List[Path]): List[Path] = {
+    val paths = if (skip) Nil else getPaths
+    if (paths.isEmpty) getLog.info(s"Skip scalafix[$flagName]")
+    else paths.foreach(dir => getLog.info(s"Processing[$flagName]: $dir"))
+    paths
   }
 
 }

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/mojo/ScalafixMojo.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/mojo/ScalafixMojo.scala
@@ -33,6 +33,12 @@ final class ScalafixMojo extends AbstractMojo {
     readonly = true)
   private var project: MavenProject = _
 
+  @Parameter(property = "scalafix.mainSourceDirectories")
+  private var mainSourceDirectories: JList[File] = _
+
+  @Parameter(property = "scalafix.testSourceDirectories")
+  private var testSourceDirectories: JList[File] = _
+
   @Parameter(property = "scalafix.mode", defaultValue = "IN_PLACE")
   private var mode: ScalafixMainMode = _
 
@@ -77,8 +83,10 @@ final class ScalafixMojo extends AbstractMojo {
 
   private def getSourceParam: MojoParam = {
     val lookup = new SourceDirectoryLookup(FileOps, project)
-    val main = checkSources("main", skipMain)(lookup.getMain(Nil))
-    val test = checkSources("test", skipTest)(lookup.getTest(Nil))
+    val main = checkSources("main", skipMain)(
+      lookup.getMain(mainSourceDirectories.asScala))
+    val test = checkSources("test", skipTest)(
+      lookup.getTest(testSourceDirectories.asScala))
     SourceDirectoryParam(main ++ test)
   }
 

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/mojo/ScalafixMojo.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/mojo/ScalafixMojo.scala
@@ -7,6 +7,7 @@ import org.apache.maven.artifact.Artifact
 import org.apache.maven.model.Plugin
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.{Mojo, Parameter, ResolutionScope}
+import org.apache.maven.project.MavenProject
 
 import scala.collection.JavaConverters._
 import scalafix.interfaces.ScalafixMainMode
@@ -24,6 +25,13 @@ final class ScalafixMojo extends AbstractMojo {
   // Scala sources. scala-maven-plugin does the same.
   // (keep one empty line after comment to avoid removal of the comment by
   // scalafix)
+
+  @Parameter(
+    property = "project",
+    defaultValue = "${project}",
+    required = true,
+    readonly = true)
+  private var project: MavenProject = _
 
   @Parameter(
     defaultValue = "${project.build.sourceDirectory}/../scala",

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/mojo/ScalafixMojo.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/mojo/ScalafixMojo.scala
@@ -7,6 +7,8 @@ import org.apache.maven.artifact.Artifact
 import org.apache.maven.model.Plugin
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.{Mojo, Parameter, ResolutionScope}
+
+import scala.collection.JavaConverters._
 import scalafix.interfaces.ScalafixMainMode
 
 //noinspection VarCouldBeVal
@@ -88,10 +90,10 @@ final class ScalafixMojo extends AbstractMojo {
         List(
           SourceDirectoryParam(sourceDirectory).ifNot(skipMain),
           SourceDirectoryParam(testSourceDirectory).ifNot(skipTest),
-          ProjectDependenciesParam(projectDependencies),
+          ProjectDependenciesParam(projectDependencies.asScala),
           CompiledDirectoryParam(compiledDirectory),
           CompiledDirectoryParam(testCompiledDirectory),
-          PluginsParam(plugins),
+          PluginsParam(plugins.asScala),
           ModeParam(mode),
           ConfigParam(config),
           CommandLineArgsParam(commandLineArgs)

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/mojo/ScalafixMojo.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/mojo/ScalafixMojo.scala
@@ -94,13 +94,13 @@ final class ScalafixMojo extends AbstractMojo {
       getLog.info(
         "Skip scalafix since both skip.main and skip.test flags passed")
     } else {
+      val mainOutputs = if (skipMain) Nil else List(compiledDirectory)
+      val testOutputs = if (skipTest) Nil else List(testCompiledDirectory)
       val params =
         List(
-          SourceDirectoryParam(sourceDirectory).ifNot(skipMain),
-          SourceDirectoryParam(testSourceDirectory).ifNot(skipTest),
+          getSourceParam,
           ProjectDependenciesParam(projectDependencies.asScala),
-          CompiledDirectoryParam(compiledDirectory),
-          CompiledDirectoryParam(testCompiledDirectory),
+          CompiledDirectoryParam(mainOutputs ++ testOutputs),
           PluginsParam(plugins.asScala),
           ModeParam(mode),
           ConfigParam(config),
@@ -109,4 +109,11 @@ final class ScalafixMojo extends AbstractMojo {
       run(params, getLog)
     }
   }
+
+  private def getSourceParam: MojoParam = {
+    val main = if (skipMain) Nil else List(sourceDirectory)
+    val test = if (skipTest) Nil else List(testSourceDirectory)
+    SourceDirectoryParam(main ++ test)
+  }
+
 }

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/CompiledDirectoryParam.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/CompiledDirectoryParam.scala
@@ -1,11 +1,11 @@
 package io.github.evis.scalafix.maven.plugin.params
 
-import java.nio.file.Paths
+object CompiledDirectoryParam extends CompiledDirectoryParam(FileOps)
 
-object CompiledDirectoryParam {
+class CompiledDirectoryParam(fileOps: FileOps) {
 
   def apply(dirs: List[String]): MojoParam = _.withClasspath {
-    dirs.map(Paths.get(_)).filter(_.toFile.exists)
+    dirs.map(fileOps.getPath).filter(x => fileOps.exists(x.toFile))
   }
 
   def apply(dirs: String*): MojoParam = apply(dirs.toList)

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/CompiledDirectoryParam.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/CompiledDirectoryParam.scala
@@ -4,7 +4,10 @@ import java.nio.file.Paths
 
 object CompiledDirectoryParam {
 
-  def apply(compiledDirectory: String): MojoParam = {
-    _.withClasspath(List(Paths.get(compiledDirectory)).filter(_.toFile.exists))
+  def apply(dirs: List[String]): MojoParam = _.withClasspath {
+    dirs.map(Paths.get(_)).filter(_.toFile.exists)
   }
+
+  def apply(dirs: String*): MojoParam = apply(dirs.toList)
+
 }

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/FileOps.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/FileOps.scala
@@ -1,0 +1,22 @@
+package io.github.evis.scalafix.maven.plugin.params
+
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+abstract class FileOps {
+
+  def exists(file: File): Boolean
+  def getPath(path: String): Path
+
+  def getFile(path: String) = getPath(path).toFile
+
+}
+
+object FileOps extends FileOps {
+
+  override def exists(file: File): Boolean = file.exists()
+
+  override def getPath(path: String) = Paths.get(path)
+
+}

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/PluginsParam.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/PluginsParam.scala
@@ -3,7 +3,6 @@ package io.github.evis.scalafix.maven.plugin.params
 import org.apache.maven.model.Plugin
 import org.codehaus.plexus.util.xml.Xpp3Dom
 
-import scala.collection.JavaConverters._
 import scala.util.Try
 
 object PluginsParam {
@@ -13,16 +12,16 @@ object PluginsParam {
     "com.triplequote.maven"
   )
 
-  def apply(plugins: java.util.List[Plugin]): MojoParam = {
+  def apply(plugins: Iterable[Plugin]): MojoParam = {
     _.withScalacOptions(
       plugins.findScalaPlugin.flatMap(config).toList.flatMap(compilerArgs))
   }
 
-  implicit private class PluginsOps(private val plugins: java.util.List[Plugin])
+  implicit private class PluginsOps(private val plugins: Iterable[Plugin])
       extends AnyVal {
 
     def findScalaPlugin: Option[Plugin] = {
-      plugins.asScala.find { plugin =>
+      plugins.find { plugin =>
         scalaPluginOrgs.contains(plugin.getGroupId) && plugin.getArtifactId == "scala-maven-plugin"
       }
     }

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/ProjectDependenciesParam.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/ProjectDependenciesParam.scala
@@ -2,12 +2,10 @@ package io.github.evis.scalafix.maven.plugin.params
 
 import org.apache.maven.artifact.Artifact
 
-import scala.collection.JavaConverters._
-
 object ProjectDependenciesParam {
 
-  def apply(projectDependencies: java.util.Set[Artifact]): MojoParam = {
-    val deps = projectDependencies.asScala.toList
+  def apply(projectDependencies: Iterable[Artifact]): MojoParam = {
+    val deps = projectDependencies.toList
     val scalaLibrary =
       deps.find { dep =>
         dep.getGroupId == "org.scala-lang" && dep.getArtifactId == "scala-library"

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/ProjectDependenciesParam.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/ProjectDependenciesParam.scala
@@ -1,5 +1,9 @@
 package io.github.evis.scalafix.maven.plugin.params
 
+import java.util.jar.JarFile
+
+import scala.util.Try
+
 import org.apache.maven.artifact.Artifact
 
 object ProjectDependenciesParam {
@@ -10,7 +14,13 @@ object ProjectDependenciesParam {
       deps.find { dep =>
         dep.getGroupId == "org.scala-lang" && dep.getArtifactId == "scala-library"
       }
-    _.withClasspath(deps.map(_.getFile.toPath))
-      .withScalaVersion(scalaLibrary.map(_.getVersion))
+    _.withClasspath(deps.flatMap { dep =>
+      /* Some dependencies could be POM files, which scalameta's ClassPathIndex
+       * (used by scalafix) would fail to load since it tries to open them using
+       * JarFile. Hence, use JarFile ourselves to filter. */
+      val file = dep.getFile
+      val ok = !file.isFile || Try(new JarFile(file)).isSuccess
+      if (ok) Some(file.toPath) else None
+    }).withScalaVersion(scalaLibrary.map(_.getVersion))
   }
 }

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryLookup.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryLookup.scala
@@ -1,0 +1,59 @@
+package io.github.evis.scalafix.maven.plugin.params
+
+import java.io.File
+import java.nio.file.Path
+import java.util.{List => JList}
+
+import scala.collection.JavaConverters._
+
+import org.apache.maven.project.MavenProject
+
+class SourceDirectoryLookup(fileOps: FileOps, project: MavenProject) {
+
+  private val build = project.getBuild()
+  private val outpath = getCanonicalFile(build.getDirectory())
+
+  def getMain(customDirs: Iterable[File]): List[Path] =
+    getFiles(
+      customDirs,
+      build.getSourceDirectory(),
+      project.getCompileSourceRoots())
+
+  def getTest(customDirs: Iterable[File]): List[Path] =
+    getFiles(
+      customDirs,
+      build.getTestSourceDirectory(),
+      project.getTestCompileSourceRoots())
+
+  private def getFiles(
+      customDirs: Iterable[File],
+      primaryDir: => String,
+      alternativeDirs: => JList[String]): List[Path] = {
+    val customDirsOpt = Option(customDirs).filter(_.nonEmpty)
+    customDirsOpt.fold {
+      val builder = Set.newBuilder[Path]
+      builder += getCanonicalFile(primaryDir + "/../scala")
+      builder ++= alternativeDirs.asScala
+        .map(getCanonicalFile)
+        .filter(!_.startsWith(outpath))
+      // check for existence only for implicit sources
+      builder.result().filter(x => fileOps.exists(x.toFile)).toList
+    }(_.map(getCanonicalFile).toList.distinct)
+  }
+
+  // Usually we execute plugin on source directory with path either like
+  // src/{main,test}/java/../scala or src/{main,test}/scala/../scala. Anyway,
+  // this path is relative, not canonical. Scalafix throws MissingTextDocument
+  // exception when tries to find sources by relative path. As a workaround, we
+  // provide canonical path for Scalafix.
+
+  private def getCanonicalFile(dir: String): Path =
+    normalize(project.getBasedir().toPath().resolve(dir))
+
+  private def getCanonicalFile(dir: File): Path =
+    normalize(project.getBasedir().toPath().resolve(dir.toPath))
+
+  private def normalize(dir: Path): Path =
+    dir.toFile().getCanonicalFile().toPath()
+
+}

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryParam.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryParam.scala
@@ -6,18 +6,7 @@ object SourceDirectoryParam extends SourceDirectoryParam(FileOps)
 
 class SourceDirectoryParam(fileOps: FileOps) {
 
-  private def create(dirs: List[Path]): MojoParam = _.withPaths(dirs)
-  def apply(dirs: String*): MojoParam = create(dirs.map(fileOps.getPath).toList)
+  def apply(dirs: List[Path]): MojoParam = _.withPaths(dirs)
+  def apply(dirs: String*): MojoParam = apply(dirs.map(fileOps.getPath).toList)
 
-  def apply(dirs: List[String]): MojoParam = _.withPaths {
-    dirs.map(getCanonicalPath).filter(x => fileOps.exists(x.toFile))
-  }
-
-  // Usually we execute plugin on source directory with path either like
-  // src/{main,test}/java/../scala or src/{main,test}/scala/../scala. Anyway,
-  // this path is relative, not canonical. Scalafix throws MissingTextDocument
-  // exception when tries to find sources by relative path. As a workaround, we
-  // provide canonical path for Scalafix.
-  private def getCanonicalPath(directory: String) =
-    fileOps.getPath(directory).toFile.getCanonicalFile.toPath
 }

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryParam.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryParam.scala
@@ -4,8 +4,8 @@ import java.nio.file.Paths
 
 object SourceDirectoryParam {
 
-  def apply(sourceDirectory: String): MojoParam = {
-    _.withPaths(List(getCanonicalPath(sourceDirectory)).filter(_.toFile.exists))
+  def apply(dirs: List[String]): MojoParam = _.withPaths {
+    dirs.map(getCanonicalPath).filter(_.toFile.exists)
   }
 
   // Usually we execute plugin on source directory with path either like

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryParam.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryParam.scala
@@ -1,8 +1,13 @@
 package io.github.evis.scalafix.maven.plugin.params
 
+import java.nio.file.Path
+
 object SourceDirectoryParam extends SourceDirectoryParam(FileOps)
 
 class SourceDirectoryParam(fileOps: FileOps) {
+
+  private def create(dirs: List[Path]): MojoParam = _.withPaths(dirs)
+  def apply(dirs: String*): MojoParam = create(dirs.map(fileOps.getPath).toList)
 
   def apply(dirs: List[String]): MojoParam = _.withPaths {
     dirs.map(getCanonicalPath).filter(x => fileOps.exists(x.toFile))

--- a/src/main/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryParam.scala
+++ b/src/main/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryParam.scala
@@ -1,11 +1,11 @@
 package io.github.evis.scalafix.maven.plugin.params
 
-import java.nio.file.Paths
+object SourceDirectoryParam extends SourceDirectoryParam(FileOps)
 
-object SourceDirectoryParam {
+class SourceDirectoryParam(fileOps: FileOps) {
 
   def apply(dirs: List[String]): MojoParam = _.withPaths {
-    dirs.map(getCanonicalPath).filter(_.toFile.exists)
+    dirs.map(getCanonicalPath).filter(x => fileOps.exists(x.toFile))
   }
 
   // Usually we execute plugin on source directory with path either like
@@ -14,5 +14,5 @@ object SourceDirectoryParam {
   // exception when tries to find sources by relative path. As a workaround, we
   // provide canonical path for Scalafix.
   private def getCanonicalPath(directory: String) =
-    Paths.get(directory).toFile.getCanonicalFile.toPath
+    fileOps.getPath(directory).toFile.getCanonicalFile.toPath
 }

--- a/src/test/scala/io/github/evis/scalafix/maven/plugin/params/CompiledDirectoryParamSpec.scala
+++ b/src/test/scala/io/github/evis/scalafix/maven/plugin/params/CompiledDirectoryParamSpec.scala
@@ -10,12 +10,10 @@ class CompiledDirectoryParamSpec extends ParamSpec {
     CompiledDirectoryParam("src/main/unexisting").applied.classpath shouldBe empty
   }
 
-  it should "add both classpaths if invoked twice on the same Scalafix arguments builder" in {
+  it should "add all classpaths if invoked with multiple" in {
     val result =
-      List(
-        CompiledDirectoryParam("src/main/scala"),
-        CompiledDirectoryParam("src/test/scala")
-      ).applied.classpath.map(_.toString)
+      CompiledDirectoryParam("src/main/scala", "src/test/scala").applied.classpath
+        .map(_.toString)
     result should contain theSameElementsAs List(
       "src/main/scala",
       "src/test/scala")

--- a/src/test/scala/io/github/evis/scalafix/maven/plugin/params/PluginsParamSpec.scala
+++ b/src/test/scala/io/github/evis/scalafix/maven/plugin/params/PluginsParamSpec.scala
@@ -5,8 +5,6 @@ import java.io.StringReader
 import org.apache.maven.model.Plugin
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder
 
-import scala.collection.JavaConverters._
-
 class PluginsParamSpec extends ParamSpec {
 
   def scalaPlugin(args: List[String]): Plugin = {
@@ -26,13 +24,13 @@ class PluginsParamSpec extends ParamSpec {
 
   "PluginsParam" should "return scalacOptions if they exist" in {
     PluginsParam(
-      List(scalaPlugin("-Xlint" :: "-Ypartial-unification" :: Nil)).asJava).applied.scalacOptions shouldBe List(
+      List(scalaPlugin("-Xlint" :: "-Ypartial-unification" :: Nil))).applied.scalacOptions shouldBe List(
       "-Xlint",
       "-Ypartial-unification")
   }
 
   it should "return no scalacOptions if they are not set" in {
-    PluginsParam(List(scalaPlugin(Nil)).asJava).applied.scalacOptions shouldBe Nil
+    PluginsParam(List(scalaPlugin(Nil))).applied.scalacOptions shouldBe Nil
   }
 
 }

--- a/src/test/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryLookupSpec.scala
+++ b/src/test/scala/io/github/evis/scalafix/maven/plugin/params/SourceDirectoryLookupSpec.scala
@@ -1,0 +1,128 @@
+package io.github.evis.scalafix.maven.plugin.params
+
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import scala.language.implicitConversions
+
+import org.apache.maven.model.Build
+import org.apache.maven.model.Model
+import org.apache.maven.project.MavenProject
+
+class SourceDirectoryLookupSpec extends ParamSpec {
+
+  import SourceDirectoryLookupSpec._
+
+  it should "add nonempty main" in {
+    // doesn't check for existence
+    val builder = new SourceDirectoryLookup(TestFileOpsNone, getMavenProject())
+    builder.getMain(Seq("foo", "/bar", "foo")) should contain theSameElementsAs
+      List[Path]("/xyz/foo", "/bar")
+  }
+
+  it should "add empty main" in {
+    val mavenBuild = new Build() {
+      setSourceDirectory("/foo/src/main/java")
+    }
+
+    val builder =
+      new SourceDirectoryLookup(TestFileOpsAll, getMavenProject(mavenBuild))
+    builder.getMain(Nil) should contain theSameElementsAs
+      List[Path]("/foo/src/main/scala")
+  }
+
+  it should "add empty main, checks for existence" in {
+    val mavenBuild = new Build() {
+      setSourceDirectory("/foo/src/main/java")
+    }
+
+    val builder =
+      new SourceDirectoryLookup(TestFileOpsNone, getMavenProject(mavenBuild))
+    builder.getMain(Nil) shouldBe empty
+  }
+
+  it should "add nonempty test" in {
+    val builder = new SourceDirectoryLookup(TestFileOpsAll, getMavenProject())
+    builder.getTest(Seq("foo", "/bar", "/bar")) should contain theSameElementsAs
+      List[Path]("/xyz/foo", "/bar")
+  }
+
+  it should "add empty test" in {
+    val mavenBuild = new Build() {
+      setTestSourceDirectory("/foo/src/test/scala")
+    }
+
+    val builder =
+      new SourceDirectoryLookup(TestFileOpsAll, getMavenProject(mavenBuild))
+    builder.getTest(Nil) should contain theSameElementsAs
+      List[Path]("/foo/src/test/scala")
+  }
+
+  it should "add empty test, checks for existence" in {
+    val mavenBuild = new Build() {
+      setTestSourceDirectory("/foo/src/test/java")
+    }
+
+    val builder =
+      new SourceDirectoryLookup(TestFileOpsNone, getMavenProject(mavenBuild))
+    builder.getTest(Nil) shouldBe empty
+  }
+
+  it should "add empty main, filtering build dir" in {
+    val mavenBuild = new Build() {
+      setSourceDirectory("/foo/src/main/java")
+    }
+    val project = getMavenProject(mavenBuild)
+    project.addCompileSourceRoot("/foo/src/main/scala")
+    project.addCompileSourceRoot("/out/src/main/scala")
+    project.addCompileSourceRoot("/out2/src/main/scala")
+
+    val builder = new SourceDirectoryLookup(TestFileOpsAll, project)
+    builder.getMain(Nil) should contain theSameElementsAs
+      List[Path]("/foo/src/main/scala", "/out2/src/main/scala")
+  }
+
+  it should "add empty test, filtering build dir" in {
+    val mavenBuild = new Build() {
+      setTestSourceDirectory("/foo/src/test/java")
+    }
+    val project = getMavenProject(mavenBuild)
+    project.addTestCompileSourceRoot("/foo/src/test/scala")
+    project.addTestCompileSourceRoot("/out/src/test/scala")
+    project.addTestCompileSourceRoot("/out2/src/test/scala")
+
+    val builder = new SourceDirectoryLookup(TestFileOpsAll, project)
+    builder.getTest(Nil) should contain theSameElementsAs
+      List[Path]("/foo/src/test/scala", "/out2/src/test/scala")
+  }
+
+}
+
+private object SourceDirectoryLookupSpec {
+
+  def getMavenProject(mavenBuild: Build): MavenProject = {
+    mavenBuild.setDirectory("/out")
+    new MavenProject(new Model { setBuild(mavenBuild) }) {
+      setFile(new File("/xyz/pom.xml")) // sets basedir
+    }
+  }
+
+  def getMavenProject(): MavenProject = getMavenProject(new Build())
+
+  implicit def implicitStringToPath(file: String): Path = Paths.get(file)
+
+  implicit def implicitStringToFile(file: String): File =
+    implicitStringToPath(file).toFile
+
+  object TestFileOpsAll extends FileOps {
+    override def exists(file: File): Boolean = true
+    override def getPath(path: String): Path = Paths.get(path)
+  }
+
+  object TestFileOpsNone extends FileOps {
+    override def exists(file: File): Boolean = false
+    override def getPath(path: String): Path = Paths.get(path)
+  }
+
+}

--- a/src/test/scala/io/github/evis/scalafix/maven/plugin/phases/BuildScalafixArgumentsSpec.scala
+++ b/src/test/scala/io/github/evis/scalafix/maven/plugin/phases/BuildScalafixArgumentsSpec.scala
@@ -10,9 +10,10 @@ class BuildScalafixArgumentsSpec extends BaseSpec with BuildScalafixArguments {
 
   "buildScalafixArguments()" should "build if source directory is given" in {
     val scalafix = new ScalafixImpl
-    val params = List(SourceDirectoryParam("src/main/scala" :: Nil))
-    val arguments = buildScalafixArguments(scalafix, params).right.value
-    arguments
+    val params = List(SourceDirectoryParam("src/main/scala"))
+    val res = buildScalafixArguments(scalafix, params)
+    res shouldBe a[Right[_, _]]
+    res.right.value
       .asInstanceOf[ScalafixArgumentsImpl]
       .args
       .files
@@ -21,14 +22,24 @@ class BuildScalafixArgumentsSpec extends BaseSpec with BuildScalafixArguments {
       .toString shouldBe "src/main/scala"
   }
 
-  it should "not build if source directory doesn't exist" in {
+  it should "not check if source directory doesn't exist" in {
     val scalafix = new ScalafixImpl
-    val params = List(SourceDirectoryParam("src/main/unexisting" :: Nil))
-    buildScalafixArguments(scalafix, params).left.value shouldBe EmptyPaths
+    val params = List(SourceDirectoryParam("src/main/unexisting"))
+    val res = buildScalafixArguments(scalafix, params)
+    res shouldBe a[Right[_, _]]
+    res.right.value
+      .asInstanceOf[ScalafixArgumentsImpl]
+      .args
+      .files
+      .loneElement
+      .toRelative
+      .toString shouldBe "src/main/unexisting"
   }
 
   it should "not build if source directory isn't given" in {
     val scalafix = new ScalafixImpl
-    buildScalafixArguments(scalafix, params = Nil).left.value shouldBe EmptyPaths
+    val res = buildScalafixArguments(scalafix, params = Nil)
+    res shouldBe a[Left[_, _]]
+    res.left.value shouldBe EmptyPaths
   }
 }

--- a/src/test/scala/io/github/evis/scalafix/maven/plugin/phases/BuildScalafixArgumentsSpec.scala
+++ b/src/test/scala/io/github/evis/scalafix/maven/plugin/phases/BuildScalafixArgumentsSpec.scala
@@ -10,7 +10,7 @@ class BuildScalafixArgumentsSpec extends BaseSpec with BuildScalafixArguments {
 
   "buildScalafixArguments()" should "build if source directory is given" in {
     val scalafix = new ScalafixImpl
-    val params = List(SourceDirectoryParam("src/main/scala"))
+    val params = List(SourceDirectoryParam("src/main/scala" :: Nil))
     val arguments = buildScalafixArguments(scalafix, params).right.value
     arguments
       .asInstanceOf[ScalafixArgumentsImpl]
@@ -23,7 +23,7 @@ class BuildScalafixArgumentsSpec extends BaseSpec with BuildScalafixArguments {
 
   it should "not build if source directory doesn't exist" in {
     val scalafix = new ScalafixImpl
-    val params = List(SourceDirectoryParam("src/main/unexisting"))
+    val params = List(SourceDirectoryParam("src/main/unexisting" :: Nil))
     buildScalafixArguments(scalafix, params).left.value shouldBe EmptyPaths
   }
 

--- a/src/test/scala/io/github/evis/scalafix/maven/plugin/phases/RunSpec.scala
+++ b/src/test/scala/io/github/evis/scalafix/maven/plugin/phases/RunSpec.scala
@@ -18,7 +18,7 @@ class RunSpec extends BaseSpec with Run {
     val log = new TestLog(LogLevel.Debug)
     val params =
       List(
-        SourceDirectoryParam("src/test/resources/project" :: Nil),
+        SourceDirectoryParam("src/test/resources/project"),
         ConfigParam(
           new File("src/test/resources/project/.success.scalafix.conf")),
         ModeParam(CHECK)
@@ -30,7 +30,7 @@ class RunSpec extends BaseSpec with Run {
     val log = new TestLog(LogLevel.Debug)
     val params =
       List(
-        SourceDirectoryParam("src/test/resources/project" :: Nil),
+        SourceDirectoryParam("src/test/resources/project"),
         ConfigParam(new File("src/test/resources/project/.fail.scalafix.conf")),
         ModeParam(CHECK)
       )

--- a/src/test/scala/io/github/evis/scalafix/maven/plugin/phases/RunSpec.scala
+++ b/src/test/scala/io/github/evis/scalafix/maven/plugin/phases/RunSpec.scala
@@ -18,7 +18,7 @@ class RunSpec extends BaseSpec with Run {
     val log = new TestLog(LogLevel.Debug)
     val params =
       List(
-        SourceDirectoryParam("src/test/resources/project"),
+        SourceDirectoryParam("src/test/resources/project" :: Nil),
         ConfigParam(
           new File("src/test/resources/project/.success.scalafix.conf")),
         ModeParam(CHECK)
@@ -30,7 +30,7 @@ class RunSpec extends BaseSpec with Run {
     val log = new TestLog(LogLevel.Debug)
     val params =
       List(
-        SourceDirectoryParam("src/test/resources/project"),
+        SourceDirectoryParam("src/test/resources/project" :: Nil),
         ConfigParam(new File("src/test/resources/project/.fail.scalafix.conf")),
         ModeParam(CHECK)
       )


### PR DESCRIPTION
Some projects use multiple source directories, such as added via http://www.mojohaus.org/build-helper-maven-plugin/. To support this case, don't pass specific parts of the project but the entire project object.