### PR TITLE
Fix Scala 2.13.8 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,7 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.major.version}</artifactId>
             <version>${scalatest.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Scalafix rule `ExplicitResultTypes` does not work on Scala 2.13.8 build because the old `scalatest` test dependency brings the transitive dependency `scala-reflect:2.13.3` into scope, which breaks the binary compatibility rules of `ExplicitResultTypes`.

This PR marks the `scalatest` dependency as a test dependency, so  `scala-reflect` is not a transitive dependency of this project anymore. Updating `scalatest` to a new version should be fixed by #24.

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ scalafix-maven-plugin_2.13 ---
[INFO] io.github.evis:scalafix-maven-plugin_2.13:maven-plugin:0.1.6_0.10.0
[INFO] \- org.scalatest:scalatest_2.13:jar:3.0.9:test
[INFO]    \- org.scala-lang:scala-reflect:jar:2.13.3:compile
```